### PR TITLE
chore: add docker-compose.override.yaml to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .env
 coverage
 dist
+docker-compose.override.yaml


### PR DESCRIPTION
ignore default override for production