### PR TITLE
WIP rename default docker volume

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,7 +23,8 @@ services:
     ports:
       - "5434:5432"
     volumes:
-      - emjpm-pgdata:/var/lib/postgresql/data
+      - emjpm-api_emjpm-pgdata:/var/lib/postgresql/data
       - ./packages/api/db/postgres-init.sh:/docker-entrypoint-initdb.d/postgres-init.sh
 volumes:
-  emjpm-pgdata:
+  emjpm-api_emjpm-pgdata:
+    external: true


### PR DESCRIPTION
Due to migration, we had to reuse the previous volume name. `external: true` allows to reuse a previous named volume