### PR TITLE
feat(api): add GET /mandataires/postcode/:postcode route

### DIFF
--- a/packages/api/__test__/e2e/mandataires/GET_postcode.test.js
+++ b/packages/api/__test__/e2e/mandataires/GET_postcode.test.js
@@ -1,0 +1,25 @@
+//
+
+const request = require("supertest");
+
+const { knex } = global;
+jest.setMock("@emjpm/api/db/knex", knex);
+
+const server = require("@emjpm/api/app");
+
+const { getTokenByUserType } = require("../utils");
+
+beforeAll(async () => {
+  await knex.migrate.latest();
+  await knex.seed.run();
+});
+
+test("should get mandataires for postcode 62000", async () => {
+  const token = await getTokenByUserType("mandataire");
+  const response = await request(server)
+    .get("/api/v1/mandataires/postcode/62000")
+    .set("Authorization", "Bearer " + token);
+
+  expect(response.body).toMatchSnapshot();
+  expect(response.status).toBe(200);
+});

--- a/packages/api/__test__/e2e/mandataires/__snapshots__/GET_postcode.test.js.snap
+++ b/packages/api/__test__/e2e/mandataires/__snapshots__/GET_postcode.test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should get mandataires for postcode 62000 1`] = `
+Object {
+  "code_postal": "62000",
+  "id": 1,
+  "latitude": 50.5333,
+  "longitude": 2.6333,
+}
+`;

--- a/packages/api/db/queries/geolocalisation_code_postal.js
+++ b/packages/api/db/queries/geolocalisation_code_postal.js
@@ -1,0 +1,11 @@
+const knex = require("../knex.js");
+
+const getCoordonneesByPostCode = codePostal =>
+  knex
+    .from("geolocalisation_code_postal")
+    .where("code_postal", codePostal)
+    .first();
+
+module.exports = {
+  getCoordonneesByPostCode
+};

--- a/packages/api/db/queries/mandataires.js
+++ b/packages/api/db/queries/mandataires.js
@@ -192,12 +192,6 @@ const update = (mandataireID, updates) =>
     .where("id", parseInt(mandataireID))
     .update(updates);
 
-const getCoordonneesByPostCode = codePostal =>
-  knex
-    .from("geolocalisation_code_postal")
-    .where("code_postal", codePostal)
-    .first();
-
 const isMandataireInTi = (mandataire_id, ti_id) =>
   knex
     .from("user_tis")
@@ -227,6 +221,5 @@ module.exports = {
   getAllServicesByTis,
   getAllMandataires,
   getAllByMandatairesFilter,
-  update,
-  getCoordonneesByPostCode
+  update
 };

--- a/packages/api/routes/mandataires.js
+++ b/packages/api/routes/mandataires.js
@@ -342,12 +342,13 @@ router.get("/services", typeRequired("ti"), async (req, res, next) => {
     .catch(next);
 });
 
-// todo: test
-
-router.post("/PosteCode", loginRequired, async (req, res, next) => {
-  getCoordonneesByPostCode(req.body.codePoste)
-    .then(mandataires => res.status(200).json(mandataires))
-    .catch(next);
+router.get("/postcode/:postcode", loginRequired, async (req, res, next) => {
+  try {
+    const mandataires = await getCoordonneesByPostCode(req.params.postcode);
+    res.status(200).json(mandataires);
+  } catch (err) {
+    next(err);
+  }
 });
 
 // ?

--- a/packages/api/routes/mandataires.js
+++ b/packages/api/routes/mandataires.js
@@ -14,9 +14,12 @@ const {
   update,
   getAllServicesByTis,
   getAllMandataires,
-  getAllByMandatairesFilter,
-  getCoordonneesByPostCode
+  getAllByMandatairesFilter
 } = require("../db/queries/mandataires");
+
+const {
+  getCoordonneesByPostCode
+} = require("../db/queries/geolocalisation_code_postal");
 
 const { updateUser } = require("../db/queries/users");
 

--- a/packages/api/routes/mandataires.js
+++ b/packages/api/routes/mandataires.js
@@ -344,8 +344,8 @@ router.get("/services", typeRequired("ti"), async (req, res, next) => {
 
 router.get("/postcode/:postcode", loginRequired, async (req, res, next) => {
   try {
-    const mandataires = await getCoordonneesByPostCode(req.params.postcode);
-    res.status(200).json(mandataires);
+    const coordonnees = await getCoordonneesByPostCode(req.params.postcode);
+    res.status(200).json(coordonnees);
   } catch (err) {
     next(err);
   }

--- a/packages/app/src/components/tiComponents/MapTi.js
+++ b/packages/app/src/components/tiComponents/MapTi.js
@@ -100,13 +100,7 @@ class MapTi extends React.Component {
     });
   };
 
-  fetchpostCode = codePostal =>
-    apiFetch("/mandataires/PosteCode", {
-      method: "POST",
-      body: JSON.stringify({
-        codePoste: codePostal
-      })
-    });
+  fetchpostCode = codePostal => apiFetch(`/mandataires/postcode/${codePostal}`);
 
   zoomCodePostal = codePostal => {
     if (!codePostal || !codePostal.trim()) {

--- a/packages/app/src/components/tiComponents/actions/map.js
+++ b/packages/app/src/components/tiComponents/actions/map.js
@@ -3,13 +3,7 @@ import apiFetch from "../../communComponents/Api";
 export const COORDINATES_UPDATED = "COORDINATES_UPDATED";
 /* ---------- API */
 
-const fetchpostCode = codePostal =>
-  apiFetch("/mandataires/PosteCode", {
-    method: "POST",
-    body: JSON.stringify({
-      codePoste: codePostal
-    })
-  });
+const fetchpostCode = codePostal => apiFetch(`/mandataires/postcode/${codePostal}`);
 /* ---------- ACTIONS CREATORS */
 
 export const zoomCodePostal = codePostal => dispatch => {


### PR DESCRIPTION
<img src=https://media.giphy.com/media/k1qeVgsr2ya0E/giphy.gif width=693>

---

**BREAKING CHANGE**: remove POST /mandataires/PosteCode route
    It feel more natural to get the postcodes from a `GET` method.