### PR TITLE
fix(docker): use a static container_name

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,7 @@ version: "3"
 services:
   db:
     image: postgres:10.3
+    container_name: emjpm-postgres
     restart: always
     environment:
       # master password


### PR DESCRIPTION
can be useful when we need to run commands on specific containers (ex: backups)