### PR TITLE
ci(gitlab): make the e2e tests run - not work

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -168,8 +168,8 @@ E2E Test @emjpm/api:
 
 E2E Test @optional/e2e:
   <<: *end_to_end_stage
+  <<: *master_based_stage
   allow_failure: true
-  image: cypress/base:12.1.0
   services:
     - name: $CI_REGISTRY_IMAGE/api:$CI_COMMIT_SHA
     - name: $CI_REGISTRY_IMAGE/app:$CI_COMMIT_SHA

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -188,4 +188,4 @@ E2E Test @optional/e2e:
     - npx wait-port --timeout 30000 localhost:4000 # 30_000 = 1000 * 30s
     # Front on localhost:80
     - npx wait-port --timeout 30000 localhost:80 # 30_000 = 1000 * 30s
-    - yarn cypress run --browser chrome
+    - yarn cypress run --headed

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -194,4 +194,6 @@ E2E Test @optional/e2e:
     - npx wait-port --timeout 30000 localhost:4000 # 30_000 = 1000 * 30s
     # Front on localhost:80
     - npx wait-port --timeout 30000 localhost:80 # 30_000 = 1000 * 30s
+    #
+    - cd /app/e2e
     - yarn cypress run --headed

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -195,5 +195,9 @@ E2E Test @optional/e2e:
     # Front on localhost:80
     - npx wait-port --timeout 30000 localhost:80 # 30_000 = 1000 * 30s
     #
+    - cd /
+    - yarn workspace @emjpm/knex run migrate --env test
+    - yarn workspace @emjpm/knex run seeds --env test
+    #
     - cd /app/e2e
     - yarn cypress run --headed

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -148,6 +148,14 @@ Register app image:
       --build-arg BASE_IMAGE=$CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
     IMAGE_NAME: $CI_REGISTRY_IMAGE/app
 
+Register e2e image:
+  <<: *register_stage
+  variables:
+    CONTEXT: optional/e2e
+    DOCKER_BUILD_ARGS: >-
+      --build-arg BASE_IMAGE=$CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
+    IMAGE_NAME: $CI_REGISTRY_IMAGE/e2e
+
 #
 
 E2E Test @emjpm/api:
@@ -169,7 +177,7 @@ E2E Test @emjpm/api:
 E2E Test @optional/e2e:
   <<: *end_to_end_stage
   allow_failure: true
-  image: cypress/base:12.1.0
+  image: $CI_REGISTRY_IMAGE/e2e
   services:
     - name: $CI_REGISTRY_IMAGE/api:$CI_COMMIT_SHA
     - name: $CI_REGISTRY_IMAGE/app:$CI_COMMIT_SHA
@@ -180,8 +188,6 @@ E2E Test @optional/e2e:
     POSTGRES_USER: postgres
     POSTGRES_PASSWORD: test
   script:
-    - cd optional/e2e
-    - yarn
     # Database on localhost:5434
     - npx wait-port --timeout 30000 localhost:5434 # 30_000 = 1000 * 30s
     # API on localhost:4000

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -187,6 +187,12 @@ E2E Test @optional/e2e:
     CYPRESS_baseUrl: "http://localhost:80"
     POSTGRES_USER: postgres
     POSTGRES_PASSWORD: test
+  artifacts:
+    expire_in: 1 week
+    when: always
+    paths:
+    - /app/e2e/cypress/screenshots
+    - /app/e2e/cypress/videos
   script:
     # Database on localhost:5434
     - npx wait-port --timeout 30000 localhost:5434 # 30_000 = 1000 * 30s
@@ -200,4 +206,4 @@ E2E Test @optional/e2e:
     - yarn workspace @emjpm/knex run seeds --env test
     #
     - cd /app/e2e
-    - yarn cypress run --headed
+    - yarn cypress run

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -177,7 +177,7 @@ E2E Test @emjpm/api:
 E2E Test @optional/e2e:
   <<: *end_to_end_stage
   allow_failure: true
-  image: $CI_REGISTRY_IMAGE/e2e
+  image: $CI_REGISTRY_IMAGE/e2e:$CI_COMMIT_SHA
   services:
     - name: $CI_REGISTRY_IMAGE/api:$CI_COMMIT_SHA
     - name: $CI_REGISTRY_IMAGE/app:$CI_COMMIT_SHA

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -168,8 +168,8 @@ E2E Test @emjpm/api:
 
 E2E Test @optional/e2e:
   <<: *end_to_end_stage
-  <<: *master_based_stage
   allow_failure: true
+  image: cypress/base:12.1.0
   services:
     - name: $CI_REGISTRY_IMAGE/api:$CI_COMMIT_SHA
     - name: $CI_REGISTRY_IMAGE/app:$CI_COMMIT_SHA

--- a/optional/e2e/Dockerfile
+++ b/optional/e2e/Dockerfile
@@ -4,7 +4,7 @@ FROM ${BASE_IMAGE} as emjpm-base-image
 
 #
 
-FROM cypress/base:10
+FROM cypress/base:10.15.3
 
 COPY ./package.json /app/e2e/package.json
 COPY ./yarn.lock /app/e2e/yarn.lock

--- a/optional/e2e/Dockerfile
+++ b/optional/e2e/Dockerfile
@@ -1,0 +1,24 @@
+ARG BASE_IMAGE=socialgouv/emjpm:master
+
+FROM ${BASE_IMAGE} as emjpm-base-image
+
+#
+
+FROM cypress/base:12.1.0
+
+COPY ./package.json /app/e2e/package.json
+COPY ./yarn.lock /app/e2e/yarn.lock
+
+WORKDIR /app/e2e
+RUN yarn --frozen-lockfile && yarn cache clean
+
+COPY ./cypress /app/e2e/cypress
+COPY ./cypress.json /app/e2e/cypress.json
+
+#
+
+COPY --from=emjpm-base-image /app/lerna.json /lerna.json
+COPY --from=emjpm-base-image /app/package.json /package.json
+COPY --from=emjpm-base-image /app/node_modules /node_modules
+
+COPY --from=emjpm-base-image /app/packages/knex /packages/knex

--- a/optional/e2e/Dockerfile
+++ b/optional/e2e/Dockerfile
@@ -4,7 +4,7 @@ FROM ${BASE_IMAGE} as emjpm-base-image
 
 #
 
-FROM cypress/base:12.1.0
+FROM cypress/base:10
 
 COPY ./package.json /app/e2e/package.json
 COPY ./yarn.lock /app/e2e/yarn.lock

--- a/packages/app/nginx.conf
+++ b/packages/app/nginx.conf
@@ -17,10 +17,6 @@ http {
     keepalive_timeout           3000;
     absolute_redirect           off;
 
-    upstream api {
-        server   api:4000;
-    }
-
     server {
         listen                  80;
         root                    /www;
@@ -36,7 +32,10 @@ http {
 
             rewrite ^/api/?(.*) /$1 break;
 
-            proxy_pass http://api;
+            # https://docs.gitlab.com/ee/ci/docker/using_docker_images.html#accessing-the-services
+            set $upstream emjpm__api:4000;
+
+            proxy_pass http://$upstream;
             proxy_redirect off;
         }
 


### PR DESCRIPTION
 - use a variable in proxy_pass destination so nginx container can startup even when target is down
 - use a k8s friendly service name