### PR TITLE
build(monorepo): ignore @optional/e2e package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dev": "lerna run dev --parallel",
     "lint": "lerna run lint --parallel",
     "start": "lerna run start --parallel",
-    "test": "lerna run test --parallel"
+    "test": "lerna run test --parallel --ignore @optional/e2e"
   },
   "devDependencies": {
     "lerna": "^3.13.4"


### PR DESCRIPTION
<img src=https://media.giphy.com/media/12Ge3LuCAofm2A/giphy.gif width=693>

--- 

As `@optional/e2e` is an optional package. 
`yarn` doesn't install cypress by default