### PR TITLE
fix(docker): make BASE_IMAGE configurable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -203,6 +203,7 @@ E2E Test @optional/e2e:
   image: $CI_REGISTRY_IMAGE/e2e:$CI_COMMIT_SHA
   services:
     - name: $CI_REGISTRY_IMAGE/api:$CI_COMMIT_SHA
+      alias: api
     - name: $CI_REGISTRY_IMAGE/app:$CI_COMMIT_SHA
     - name: $CI_REGISTRY_IMAGE/postgres:$CI_COMMIT_SHA
       command: ["-p", "5434", "-c", "fsync=off", "-c", "synchronous_commit=off", "-c", "full_page_writes=off"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,13 @@ WORKDIR /app
 
 RUN yarn --frozen-lockfile && yarn cache clean
 
-#
-
 COPY ./packages/jest-environment-knex /app/packages/jest-environment-knex
 COPY ./optional/e2e /app/optional/e2e
 COPY ./packages/knex /app/packages/knex
 COPY ./packages/api /app/packages/api
 COPY ./packages/app /app/packages/app
+
+ARG API_URL=${API_URL:-/api}
+ARG SENTRY_PUBLIC_DSN=${SENTRY_PUBLIC_DSN:-https://path.to.sentry}
 
 RUN yarn build --stream

--- a/README.md
+++ b/README.md
@@ -57,14 +57,13 @@ $ yarn run -- lerna --scope @optional/e2e run cypress:run -- --headed
 
 ## Manual deployment
 
-To deploy manually some version :
+To build and deploy manually some version :
 
 ```sh
-
 # checkout your target branch
 git pull
 
-# edit docker-compose.override.yml and .env
+# edit docker-compose.override.yaml and .env
 
 # build locally main docker image as emjpm-base
 # you can override API_URL and SENTRY_PUBLIC_DSN env vars here
@@ -74,8 +73,8 @@ docker build . -t emjpm-base
 BASE_IMAGE=emjpm-base docker-compose up --build -d
 
 # run migrations and seeds
-docker-compose run knex yarn workspace @emjpm/knex run migrate
-docker-compose run knex yarn workspace @emjpm/knex run seeds
+BASE_IMAGE=emjpm-base docker-compose run knex yarn workspace @emjpm/knex run migrate
+BASE_IMAGE=emjpm-base docker-compose run knex yarn workspace @emjpm/knex run seeds
 ```
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -55,6 +55,30 @@ $ NODE_ENV=test yarn workspace @emjpm/knex run seeds
 $ yarn run -- lerna --scope @optional/e2e run cypress:run -- --headed
 ```
 
+## Manual deployment
+
+To deploy manually some version :
+
+```sh
+
+# checkout your target branch
+git pull
+
+# edit docker-compose.override.yml and .env
+
+# build locally main docker image as emjpm-base
+# you can override API_URL and SENTRY_PUBLIC_DSN env vars here
+docker build . -t emjpm-base
+
+# rebuild and launch instance using locally built image
+BASE_IMAGE=emjpm-base docker-compose up --build -d
+
+# run migrations and seeds
+
+docker-compose exec api migrate:latest
+docker-compose exec api seeds:run
+```
+
 ## FAQ
 
 - _If you have the `Can't take lock to run migrations: Migration table is already locked` error_

--- a/README.md
+++ b/README.md
@@ -74,9 +74,8 @@ docker build . -t emjpm-base
 BASE_IMAGE=emjpm-base docker-compose up --build -d
 
 # run migrations and seeds
-
-docker-compose exec api migrate:latest
-docker-compose exec api seeds:run
+docker-compose run knex yarn workspace @emjpm/knex run migrate
+docker-compose run knex yarn workspace @emjpm/knex run seeds
 ```
 
 ## FAQ

--- a/docker-compose.override.yaml.sample
+++ b/docker-compose.override.yaml.sample
@@ -36,6 +36,12 @@ services:
     restart: always
     ports:
       - 1080:80
+  # Useful to run arbitrary knex commands
+  knex:
+    restart: "no"
+    image: ${BASE_IMAGE:-socialgouv/emjpm:master}
+    env_file: .env
+  # Production API (NodeJS)
   api:
     restart: always
     build:
@@ -48,6 +54,7 @@ services:
       - 4000:4000
     depends_on:
       - db
+  # Production frontend (nginx)
   frontend:
     restart: always
     env_file: .env

--- a/docker-compose.override.yaml.sample
+++ b/docker-compose.override.yaml.sample
@@ -41,12 +41,12 @@ services:
     build:
       context: packages/api
       dockerfile: Dockerfile
+      args:
+        BASE_IMAGE: ${BASE_IMAGE:-socialgouv/emjpm:master}
     env_file: .env
     ports:
       - 4000:4000
     depends_on:
-      - db
-    links:
       - db
   frontend:
     restart: always
@@ -54,22 +54,13 @@ services:
     build:
       context: ./packages/app
       dockerfile: Dockerfile
-      #
-      # this app is built statically so we cannot inject env vars at runtime
-      # we use args to expose them as env var *during the build phase, inside the container*
-      #
       args:
-        API_URL: "/api"
-        SENTRY_PUBLIC_DSN: $SENTRY_PUBLIC_DSN
-    depends_on:
-      - api
-    links:
-      - api
-      - api:emjpm__api
+        BASE_IMAGE: ${BASE_IMAGE:-socialgouv/emjpm:master}
     ports:
       - 5000:80
     volumes:
       - ./nginx-logs:/var/log/nginx
+
 
 volumes:
   metabase:

--- a/packages/app/Dockerfile
+++ b/packages/app/Dockerfile
@@ -7,3 +7,5 @@ FROM nginx:1.16-alpine
 COPY --from=emjpm-base-image /app/packages/app/out /www
 
 COPY nginx.conf /etc/nginx/nginx.conf
+
+EXPOSE 80

--- a/packages/app/Dockerfile
+++ b/packages/app/Dockerfile
@@ -1,5 +1,3 @@
-ARG API_URL
-ARG SENTRY_PUBLIC_DSN
 ARG BASE_IMAGE=socialgouv/emjpm:master
 
 FROM ${BASE_IMAGE} as emjpm-base-image

--- a/packages/app/next.config.js
+++ b/packages/app/next.config.js
@@ -26,3 +26,4 @@ module.exports = withTM(
     })
   )
 );
+

--- a/packages/app/nginx.conf
+++ b/packages/app/nginx.conf
@@ -32,10 +32,7 @@ http {
 
             rewrite ^/api/?(.*) /$1 break;
 
-            # https://docs.gitlab.com/ee/ci/docker/using_docker_images.html#accessing-the-services
-            set $upstream emjpm__api:4000;
-
-            proxy_pass http://$upstream;
+            proxy_pass http://api:4000;
             proxy_redirect off;
         }
 


### PR DESCRIPTION
Plusieurs fixes pour pouvoir faire tourner un environnement docker-compose from scratch :

 - passage des `ARG` de build docker pour l'app statique
 - possibilité de build les images docker localement et de passer le `BASE_IMAGE` à docker-compose
 - gitlab-ci : rename du service `emjpm__api` en `api`
 - ajout d'un service docker-compose `knex` basé sur l'image docker principale qui permet de run des commandes knex sur un env existant (ex: migrate, seeds...)