### PR TITLE
build(app): re-use a $upstream variable in nginx config

### DIFF
--- a/packages/app/nginx.conf
+++ b/packages/app/nginx.conf
@@ -32,7 +32,10 @@ http {
 
             rewrite ^/api/?(.*) /$1 break;
 
-            proxy_pass http://api:4000;
+            # https://docs.gitlab.com/ee/ci/docker/using_docker_images.html#accessing-the-services
+            set $upstream api:4000;
+
+            proxy_pass http://$upstream;
             proxy_redirect off;
         }
 


### PR DESCRIPTION
Ensure that nginx starts even if the api is not up
Partial revert https://github.com/SocialGouv/emjpm/commit/274aae79ce28ca3bdc16a657bd7efd2317fb27bd 
\following https://github.com/SocialGouv/emjpm/pull/247