### PR TITLE
build(docker): ignore more stuff

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,8 @@
-.next
-dist
-node_modules
-out
+*.md
+.git
+**/dist
+**/build
+**/node_modules
+**/.next
+**/coverage
+scripts


### PR DESCRIPTION
<img src=https://media.giphy.com/media/1uC8xfkZRi7Kw/giphy.gif width=693>

---

BEFORE

```
$ docker build $DOCKER_BUILD_ARGS --cache-from $IMAGE_NAME:$CI_COMMIT_BEFORE_SHA -t $IMAGE_NAME:$CI_COMMIT_SHA $CONTEXT
Sending build context to Docker daemon  24.57MB
```

AFTER

```
$ docker build $DOCKER_BUILD_ARGS --cache-from $IMAGE_NAME:$CI_COMMIT_BEFORE_SHA -t $IMAGE_NAME:$CI_COMMIT_SHA $CONTEXT
Sending build context to Docker daemon  3.332MB
```