### PR TITLE
fix(app): add missing returns

### DIFF
--- a/packages/app/src/components/inscription/Form.js
+++ b/packages/app/src/components/inscription/Form.js
@@ -10,16 +10,16 @@ import Router from "next/router";
 
 const formsMandataires = {
   individuel(props) {
-    <InscriptionIndividuel {...props} />;
+    return <InscriptionIndividuel {...props} />;
   },
   prepose(props) {
-    <InscriptionPrepose {...props} />;
+    return <InscriptionPrepose {...props} />;
   },
   service(props) {
-    <InscriptionService {...props} />;
+    return <InscriptionService {...props} />;
   },
   ti(props) {
-    <InscriptionTi {...props} />;
+    return <InscriptionTi {...props} />;
   }
 };
 


### PR DESCRIPTION
Prevent `Nothing was returned from render. This usually means a return statement is missing. Or, to render nothing, return null.`