### PR TITLE
fix(knex): use postgres user locally

### DIFF
--- a/packages/knex/knexfile.js
+++ b/packages/knex/knexfile.js
@@ -8,7 +8,7 @@ module.exports = {
     client: "pg",
     connection: process.env.DATABASE_URL || {
       host: "localhost",
-      user: "emjpm",
+      user: "postgres",
       password: "test",
       port: "5434",
       database: "emjpm"
@@ -24,7 +24,7 @@ module.exports = {
     client: "pg",
     connection: process.env.DATABASE_URL || {
       host: "localhost",
-      user: "emjpm",
+      user: "postgres",
       password: "test",
       port: "5434",
       database: "emjpm"
@@ -40,7 +40,7 @@ module.exports = {
     client: "pg",
     connection: process.env.DATABASE_URL || {
       host: "localhost",
-      user: "emjpm",
+      user: "postgres",
       password: "test",
       port: "5434",
       database: "emjpm"


### PR DESCRIPTION
The uesr `emjpm` can't change triggers

```
$ yarn workspace @emjpm/knex run migrate --env test      
yarn workspace v1.17.3
yarn run v1.17.3
$ knex migrate:latest --env test
Using environment: test
migration file "20190923112826_update_trigger_mesures_counter.js" failed
migration failed with error: 
DROP TRIGGER on_update_mesures ON mesures;
DROP FUNCTION update_gestionnaire_counters;


 CREATE OR REPLACE FUNCTION update_gestionnaire_counters() RETURNS trigger AS $$
  BEGIN
   IF (TG_OP = 'UPDATE' and new.antenne_id is not null) THEN
    perform update_antenne_counters(new.antenne_id);
    IF (old.antenne_id  <> new.antenne_id) THEN
      perform update_antenne_counters(old.antenne_id);
    END IF;
    return new;
   elseif (TG_OP = 'UPDATE' and new.mandataire_id is not null) then perform  update_mandataire_counters(new.mandataire_id); return new;
   elseif (TG_OP = 'INSERT' and new.antenne_id is not null) then perform  update_antenne_counters(new.antenne_id); return new;
   elseif (TG_OP = 'INSERT' and new.mandataire_id is not null) then perform  update_mandataire_counters(new.mandataire_id); return new;
   elseif (TG_OP = 'DELETE' and old.antenne_id is not null) then perform  update_antenne_counters(old.antenne_id); return old;
   elseif (TG_OP = 'DELETE' and old.mandataire_id is not null) then perform  update_mandataire_counters(old.mandataire_id); return old;
   end if;
  END;
 $$ language 'plpgsql';

CREATE TRIGGER on_update_mesures
 AFTER update of status, antenne_id or delete or insert ON mesures
 FOR EACH row
 EXECUTE PROCEDURE update_gestionnaire_counters();
   - must be owner of function update_gestionnaire_counters
error: must be owner of function update_gestionnaire_counters
    at Connection.parseE (/home/x/zzz/github/douglasduteil/emjpm/node_modules/pg/lib/connection.js:604:11)
    at Connection.parseMessage (/home/x/zzz/github/douglasduteil/emjpm/node_modules/pg/lib/connection.js:401:19)
    at Socket.<anonymous> (/home/x/zzz/github/douglasduteil/emjpm/node_modules/pg/lib/connection.js:121:22)
    at Socket.emit (events.js:203:13)
    at addChunk (_stream_readable.js:294:12)
    at readableAddChunk (_stream_readable.js:275:11)
    at Socket.Readable.push (_stream_readable.js:210:10)
    at TCP.onStreamRead (internal/stream_base_commons.js:166:17)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed.
Exit code: 1

```

The `postgres` do :kiss:

```
$ yarn workspace @emjpm/knex run migrate --env test
yarn workspace v1.17.3
yarn run v1.17.3
$ knex migrate:latest --env test
Using environment: test
Batch 16 run: 1 migrations
Done in 1.61s.
Done in 2.24s.
```

---

<img src=https://media.giphy.com/media/fsPuwFXsrtT4jTxcnl/giphy.gif width=693>