### PR TITLE
chore(app): add @types/node peer dependency

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -73,6 +73,7 @@
     "@babel/cli": "^7.7.7",
     "@babel/core": "^7.7.7",
     "@socialgouv/eslint-config-react": "^0.11.1",
+    "@types/node": "^12.12.21",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.0.3",
     "enzyme": "^3.9.0",


### PR DESCRIPTION
Required by "@emjpm/app > next > native-url@0.2.3" has unmet peer dependency "@types/node@>=8.0.0".