### PR TITLE
chore(app): add @types/react peer dependency

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -74,6 +74,7 @@
     "@babel/core": "^7.7.7",
     "@socialgouv/eslint-config-react": "^0.11.1",
     "@types/node": "^12.12.21",
+    "@types/react": "^16.9.16",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.0.3",
     "enzyme": "^3.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3611,7 +3611,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
+"@types/react@*", "@types/react@^16.9.16":
   version "16.9.16"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.16.tgz#4f12515707148b1f53a8eaa4341dae5dfefb066d"
   integrity sha512-dQ3wlehuBbYlfvRXfF5G+5TbZF3xqgkikK7DWAsQXe2KnzV+kjD4W2ea+ThCrKASZn9h98bjjPzoTYzfRqyBkw==


### PR DESCRIPTION
Required by :
- @emjpm/app > react-apollo@3.1.3" has unmet peer dependency "@types/react@^16.8.0".
- @emjpm/app > react-apollo@3.1.3" has unmet peer dependency "apollo-client@^2.6.4".
- @emjpm/app > react-apollo > @apollo/react-common@3.1.3" has unmet peer dependency "@types/react@^16.8.0"