### PR TITLE
build(k8s): allow data injection job to go up to 0.5 CPU

### DIFF
--- a/.k8s/postgres/dataset/job-inject-dataset.yml
+++ b/.k8s/postgres/dataset/job-inject-dataset.yml
@@ -32,7 +32,7 @@ spec:
               cpu: 0m
               memory: 0Mi
             limits:
-              cpu: 250m
+              cpu: 500m
               memory: 256Mi
       volumes:
         - name: dataset


### PR DESCRIPTION
<img src=https://media.giphy.com/media/gfqo8gdAiNUrZ0aa99/giphy.gif width=693>