### PR TITLE
feat(admin): affichage des mesures

### DIFF
--- a/packages/app/src/components/AdminServices/queries.js
+++ b/packages/app/src/components/AdminServices/queries.js
@@ -36,19 +36,13 @@ export const MESURES = gql`
       mesures_awaiting
       mesures_in_progress
     }
-    mesures_aggregate(
-      where: { service_id: { _eq: $serviceId }, status: { _eq: "Mesure en attente" } }
-    ) {
-      aggregate {
-        count
-      }
-    }
-    mesures(where: { service_id: { _eq: $serviceId }, status: { _eq: "Mesure en cours" } }) {
+    mesures(where: { service_id: { _eq: $serviceId } }) {
       id
       etablissement
       numero_dossier
       residence
       numero_rg
+      status
       date_ouverture
       created_at
       ti {

--- a/packages/app/src/components/AdminUsers/queries.js
+++ b/packages/app/src/components/AdminUsers/queries.js
@@ -32,16 +32,7 @@ export const MESURES = gql`
       mesures_en_cours
       id
     }
-    mesures_aggregate(
-      where: { mandataire: { user_id: { _eq: $userId } }, status: { _eq: "Mesure en attente" } }
-    ) {
-      aggregate {
-        count
-      }
-    }
-    mesures(
-      where: { mandataire: { user_id: { _eq: $userId } }, status: { _eq: "Mesure en cours" } }
-    ) {
+    mesures(where: { mandataire: { user_id: { _eq: $userId } } }) {
       id
       etablissement
       numero_dossier

--- a/packages/app/src/constants/mesures.js
+++ b/packages/app/src/constants/mesures.js
@@ -31,15 +31,22 @@ export const MESURE_RESIDENCES = [
 
 export const MESURE_CIVILITIES = ["F", "H"];
 
+export const MESURE_STATUS_LABEL_VALUE_EN_COURS = {
+  label: "Mesure en cours",
+  value: "Mesure en cours"
+};
+export const MESURE_STATUS_LABEL_VALUE_ETEINTE = {
+  label: "Mesure éteinte",
+  value: "Eteindre mesure"
+};
+export const MESURE_STATUS_LABEL_VALUE_ATTENTE = {
+  label: "Mesure en attente",
+  value: "Mesure en attente"
+};
+
 export const MESURE_STATUS_LABEL_VALUE = [
-  {
-    label: "Mesure en cours",
-    value: "Mesure en cours"
-  },
-  {
-    label: "Mesure éteinte",
-    value: "Eteindre mesure"
-  }
+  MESURE_STATUS_LABEL_VALUE_EN_COURS,
+  MESURE_STATUS_LABEL_VALUE_ETEINTE
 ];
 
 export const DEFAULT_MESURE_TYPE = {


### PR DESCRIPTION
Fix https://github.com/SocialGouv/emjpm/issues/1714

Sur la page d'un utilisateurs dans l'espace administrateur, je souhaite:
- [x] voir les mesures `Mesure en attente`, `Mesure en cours` et 'Mesure éteinte'
- [x] avoir un filtre pour sélectionner pour sélectionner le `state`
- [x] Par défaut, le filtre est à `Mesure en cours`

Sur la page d'un service de l'espace administrateur, je souhaite:
- [x] voir les mesures `Mesure en attente`, `Mesure en cours` et 'Mesure éteinte'
- [x] avoir un filtre pour sélectionner pour sélectionner le `state`
- [x] Par défaut, le filtre est à `Mesure en cours`