### PR TITLE
feat(enquete): fix mandataire infos generales + formation

### DIFF
--- a/packages/api/src/routes/hasura-actions/enquete/common/enquete-status/informations_mandataire/enqueteInformationsMandatairesStatus.js
+++ b/packages/api/src/routes/hasura-actions/enquete/common/enquete-status/informations_mandataire/enqueteInformationsMandatairesStatus.js
@@ -21,8 +21,21 @@ module.exports = async enqueteReponse => {
         }),
         anciennete: yup.string().required(),
         estimation_etp: yup.string().required(),
-        exerce_secretaires_specialises: yup.boolean().nullable(),
-        secretaire_specialise_etp: yup.number().nullable(),
+        exerce_seul_activite: yup.boolean().required(),
+        exerce_secretaires_specialises: yup.boolean().required(),
+        secretaire_specialise_etp: yup
+          .number()
+          .when("exerce_secretaires_specialises", {
+            is: true,
+            then: yup
+              .number()
+              .positive()
+              .required(), // > 0
+            otherwise: yup
+              .number()
+              .oneOf([0])
+              .nullable() // 0 or empty
+          }),
         local_professionnel: yup.boolean().required()
       }),
       "informationsGenerales/agrementsStatus"

--- a/packages/app/src/components/Enquete/EnqueteIndividuel/enqueteIndividuelMenuBuilder.service.js
+++ b/packages/app/src/components/Enquete/EnqueteIndividuel/enqueteIndividuelMenuBuilder.service.js
@@ -12,9 +12,9 @@ import {
   EnqueteActiviteTutelle
 } from "../EnqueteActivite";
 import {
-  EnqueteIndividuelInformations,
   EnqueteIndividuelInformationsAgrements,
-  EnqueteIndividuelInformationsFormation
+  EnqueteIndividuelInformationsFormation,
+  EnqueteIndividuelInformationsMandataire
 } from "../EnqueteIndividuelInformations";
 import { EnqueteIndividuelPrestationsSociales } from "../EnqueteIndividuelPrestationsSociales";
 import {
@@ -51,7 +51,7 @@ function buildMenuSections(enqueteReponse) {
       steps: [
         {
           label: "Informations générales",
-          component: EnqueteIndividuelInformations,
+          component: EnqueteIndividuelInformationsMandataire,
           status: status.informations.informationsGenerales
         },
         {

--- a/packages/app/src/components/Enquete/EnqueteIndividuelInformations/EnqueteIndividuelInformationsFormationForm.js
+++ b/packages/app/src/components/Enquete/EnqueteIndividuelInformations/EnqueteIndividuelInformationsFormationForm.js
@@ -24,12 +24,12 @@ export const validationSchema = yup.object().shape({
     .max(6)
     .integer()
     .required(),
-  secretaire_specialise_etp_n1: yup.number().positive(),
-  secretaire_specialise_etp_spe_n2: yup.number().positive(),
-  secretaire_specialise_etp_spe_n3: yup.number().positive(),
-  secretaire_specialise_etp_spe_n4: yup.number().positive(),
-  secretaire_specialise_etp_spe_n5: yup.number().positive(),
-  secretaire_specialise_etp_spe_n6: yup.number().positive()
+  secretaire_specialise_etp_n1: yup.number().min(0),
+  secretaire_specialise_etp_spe_n2: yup.number().min(0),
+  secretaire_specialise_etp_spe_n3: yup.number().min(0),
+  secretaire_specialise_etp_spe_n4: yup.number().min(0),
+  secretaire_specialise_etp_spe_n5: yup.number().min(0),
+  secretaire_specialise_etp_spe_n6: yup.number().min(0)
 });
 
 function mapDataPropsToFormValues(data) {
@@ -158,7 +158,6 @@ export const EnqueteIndividuelInformationsFormationForm = props => {
             value={values.secretaire_specialise_etp_n1}
             hasError={showError && !!errors.secretaire_specialise_etp_n1}
             onChange={handleChange}
-            min={0}
           />
           <InlineError
             showError={showError}
@@ -178,7 +177,6 @@ export const EnqueteIndividuelInformationsFormationForm = props => {
             value={values.secretaire_specialise_etp_n2}
             hasError={showError && !!errors.secretaire_specialise_etp_n2}
             onChange={handleChange}
-            min={0}
           />
           <InlineError
             showError={showError}
@@ -198,7 +196,6 @@ export const EnqueteIndividuelInformationsFormationForm = props => {
             value={values.secretaire_specialise_etp_n3}
             hasError={showError && !!errors.secretaire_specialise_etp_n3}
             onChange={handleChange}
-            min={0}
           />
           <InlineError
             showError={showError}
@@ -218,7 +215,6 @@ export const EnqueteIndividuelInformationsFormationForm = props => {
             value={values.secretaire_specialise_etp_n4}
             hasError={showError && !!errors.secretaire_specialise_etp_n4}
             onChange={handleChange}
-            min={0}
           />
           <InlineError
             showError={showError}
@@ -238,7 +234,6 @@ export const EnqueteIndividuelInformationsFormationForm = props => {
             value={values.secretaire_specialise_etp_n5}
             hasError={showError && !!errors.secretaire_specialise_etp_n5}
             onChange={handleChange}
-            min={0}
           />
           <InlineError
             showError={showError}
@@ -258,7 +253,6 @@ export const EnqueteIndividuelInformationsFormationForm = props => {
             value={values.secretaire_specialise_etp_n6}
             hasError={showError && !!errors.secretaire_specialise_etp_n6}
             onChange={handleChange}
-            min={0}
           />
           <InlineError
             showError={showError}

--- a/packages/app/src/components/Enquete/EnqueteIndividuelInformations/EnqueteIndividuelInformationsMandataire.js
+++ b/packages/app/src/components/Enquete/EnqueteIndividuelInformations/EnqueteIndividuelInformationsMandataire.js
@@ -2,11 +2,11 @@ import { useMutation, useQuery } from "@apollo/react-hooks";
 import React from "react";
 
 import { ENQUETE_MANDATAIRE_INDIVIDUEL } from "../EnqueteIndividuel/queries";
-import { EnqueteIndividuelInformationsForm } from "./EnqueteIndividuelInformationsForm";
+import { EnqueteIndividuelInformationsMandataireForm } from "./EnqueteIndividuelInformationsMandataireForm";
 import { UPDATE_ENQUETE_INDIVIDUEL_INFORMATIONS } from "./mutations";
 import { ENQUETE_INDIVIDUEL_INFORMATIONS_MANDATAIRE } from "./queries";
 
-export const EnqueteIndividuelInformations = props => {
+export const EnqueteIndividuelInformationsMandataire = props => {
   const {
     goToNextPage,
     goToPrevPage,
@@ -39,7 +39,7 @@ export const EnqueteIndividuelInformations = props => {
 
   const informations = data ? data.enquete_reponses_informations_mandataire_by_pk || {} : {};
   return loading ? null : (
-    <EnqueteIndividuelInformationsForm
+    <EnqueteIndividuelInformationsMandataireForm
       data={informations}
       section={section}
       step={step}
@@ -59,6 +59,7 @@ export const EnqueteIndividuelInformations = props => {
             estimation_etp: values.estimation_etp || null,
             forme_juridique: values.forme_juridique ? values.forme_juridique : null,
             local_professionnel: values.local_professionnel,
+            exerce_seul_activite: values.exerce_seul_activite,
             secretaire_specialise_etp:
               values.secretaire_specialise_etp &&
               !isNaN(parseFloat(values.secretaire_specialise_etp))
@@ -72,4 +73,4 @@ export const EnqueteIndividuelInformations = props => {
   );
 };
 
-export default EnqueteIndividuelInformations;
+export default EnqueteIndividuelInformationsMandataire;

--- a/packages/app/src/components/Enquete/EnqueteIndividuelInformations/EnqueteIndividuelInformationsMandataireForm.js
+++ b/packages/app/src/components/Enquete/EnqueteIndividuelInformations/EnqueteIndividuelInformationsMandataireForm.js
@@ -23,8 +23,19 @@ const validationSchema = yup.object().shape({
   }),
   anciennete: yup.string().required(),
   estimation_etp: yup.string().required(),
-  exerce_secretaires_specialises: yup.boolean().nullable(),
-  secretaire_specialise_etp: yup.number().nullable(),
+  exerce_seul_activite: yup.boolean().required(),
+  exerce_secretaires_specialises: yup.boolean().required(),
+  secretaire_specialise_etp: yup.number().when("exerce_secretaires_specialises", {
+    is: true,
+    then: yup
+      .number()
+      .positive()
+      .required(), // > 0
+    otherwise: yup
+      .number()
+      .oneOf([0], 'Vous avez répondu "non" à la question précédente, donc ce champ doit être vide.')
+      .nullable() // 0 or empty
+  }),
   local_professionnel: yup.boolean().required()
 });
 
@@ -37,6 +48,7 @@ function mapDataPropsToFormValues(data) {
     anciennete: data.anciennete || "",
     estimation_etp: data.estimation_etp || "",
     forme_juridique: data.forme_juridique || "",
+    exerce_seul_activite: data.exerce_seul_activite || false,
     exerce_secretaires_specialises: data.exerce_secretaires_specialises || false,
     secretaire_specialise_etp: data.secretaire_specialise_etp || "",
     local_professionnel: data.local_professionnel || false,
@@ -45,7 +57,7 @@ function mapDataPropsToFormValues(data) {
   };
 }
 
-export const EnqueteIndividuelInformationsForm = props => {
+export const EnqueteIndividuelInformationsMandataireForm = props => {
   const { data = {}, step, goToPrevPage } = props;
 
   const {
@@ -225,7 +237,19 @@ export const EnqueteIndividuelInformationsForm = props => {
         <Text mt={7} mb={4} fontWeight="bold" color="#595959">
           {"CONDITIONS D'EXERCICE DE L'ACTIVITE"}
         </Text>
-
+        <Field>
+          <Label mb={1}>{"Exercez-vous seul l'activité ?"}</Label>
+          <YesNoComboBox
+            defaultValue={values.exerce_seul_activite}
+            name="exerce_seul_activite"
+            onChange={value => setFieldValue("exerce_seul_activite", value)}
+          />
+          <InlineError
+            showError={showError}
+            message={errors.exerce_seul_activite}
+            fieldId="exerce_seul_activite"
+          />
+        </Field>
         <Field>
           <Label mb={1} htmlFor="estimation_etp">
             {"Estimation de l'activité en équivalent temps plein (ETP)"}
@@ -253,12 +277,7 @@ export const EnqueteIndividuelInformationsForm = props => {
           <YesNoComboBox
             defaultValue={values.exerce_secretaires_specialises}
             name="exerce_secretaires_specialises"
-            onChange={value => {
-              setFieldValue("exerce_secretaires_specialises", value);
-              if (!value) {
-                setFieldValue("exerce_secretaires_specialises", "");
-              }
-            }}
+            onChange={value => setFieldValue("exerce_secretaires_specialises", value)}
           />
           <InlineError
             showError={showError}
@@ -267,7 +286,7 @@ export const EnqueteIndividuelInformationsForm = props => {
           />
         </Field>
 
-        {values.exerce_secretaires_specialises && (
+        {(values.exerce_secretaires_specialises || !!errors.secretaire_specialise_etp) && (
           <Field>
             <Label mb={1} htmlFor="secretaire_specialise_etp">
               {"Estimation de l'activité en ETP du secrétariat spécialisé"}
@@ -309,4 +328,4 @@ export const EnqueteIndividuelInformationsForm = props => {
   );
 };
 
-export default EnqueteIndividuelInformationsForm;
+export default EnqueteIndividuelInformationsMandataireForm;

--- a/packages/app/src/components/Enquete/EnqueteIndividuelInformations/EnqueteIndividuelInformationsMandataireForm.test.js
+++ b/packages/app/src/components/Enquete/EnqueteIndividuelInformations/EnqueteIndividuelInformationsMandataireForm.test.js
@@ -3,12 +3,12 @@ import React from "react";
 
 import { INTERVALLE_ETP_OPTIONS } from "../../../constants/mandataire";
 import { render } from "../../../util/test-utils";
-import { EnqueteIndividuelInformationsForm } from "./EnqueteIndividuelInformationsForm";
+import { EnqueteIndividuelInformationsMandataireForm } from "./EnqueteIndividuelInformationsMandataireForm";
 
 test("it should naviguate to previous step", async () => {
   var goToPrevPageMock = jest.fn();
   const { getByText } = render(
-    <EnqueteIndividuelInformationsForm goToPrevPage={goToPrevPageMock} />
+    <EnqueteIndividuelInformationsMandataireForm goToPrevPage={goToPrevPageMock} />
   );
   const prevButton = getByText("Précédent");
   userEvent.click(prevButton);
@@ -26,7 +26,7 @@ test("it should display initial values", () => {
   };
 
   const { getByLabelText } = render(
-    <EnqueteIndividuelInformationsForm data={data} handleSubmit={() => jest.fn()} />
+    <EnqueteIndividuelInformationsMandataireForm data={data} handleSubmit={() => jest.fn()} />
   );
 
   const formeJuridique = getByLabelText(/Forme juridique de votre entreprise/i);
@@ -44,13 +44,13 @@ test('it should display "forme juridique" field when "benevole" field is not sel
     forme_juridique: "Autoentrepreneur"
   };
 
-  const { getByLabelText } = render(<EnqueteIndividuelInformationsForm data={data} />);
+  const { getByLabelText } = render(<EnqueteIndividuelInformationsMandataireForm data={data} />);
   expect(getByLabelText(/Forme juridique de votre entreprise/i)).toHaveValue("Autoentrepreneur");
 });
 
 test('it should hide "forme juridique" field when "benevole" field is selected', () => {
   const { queryByLabelText } = render(
-    <EnqueteIndividuelInformationsForm data={{ benevole: true }} />
+    <EnqueteIndividuelInformationsMandataireForm data={{ benevole: true }} />
   );
   expect(queryByLabelText(/Forme juridique de votre entreprise/i)).toBeNull();
 });

--- a/packages/app/src/components/Enquete/EnqueteIndividuelInformations/index.js
+++ b/packages/app/src/components/Enquete/EnqueteIndividuelInformations/index.js
@@ -1,3 +1,3 @@
-export { EnqueteIndividuelInformations } from "./EnqueteIndividuelInformations";
+export { EnqueteIndividuelInformationsMandataire } from "./EnqueteIndividuelInformationsMandataire";
 export { EnqueteIndividuelInformationsFormation } from "./EnqueteIndividuelInformationsFormation";
 export { EnqueteIndividuelInformationsAgrements } from "./EnqueteIndividuelInformationsAgrements";

--- a/packages/app/src/components/Enquete/EnqueteIndividuelInformations/mutations.js
+++ b/packages/app/src/components/Enquete/EnqueteIndividuelInformations/mutations.js
@@ -77,6 +77,7 @@ export const UPDATE_ENQUETE_INDIVIDUEL_INFORMATIONS = gql`
     $benevole: Boolean
     $estimation_etp: String
     $forme_juridique: String
+    $exerce_seul_activite: Boolean
     $local_professionnel: Boolean
     $secretaire_specialise_etp: Float
     $sexe: String
@@ -93,6 +94,7 @@ export const UPDATE_ENQUETE_INDIVIDUEL_INFORMATIONS = gql`
         estimation_etp: $estimation_etp
         forme_juridique: $forme_juridique
         local_professionnel: $local_professionnel
+        exerce_seul_activite: $exerce_seul_activite
         secretaire_specialise_etp: $secretaire_specialise_etp
         sexe: $sexe
         tranche_age: $tranche_age
@@ -102,6 +104,7 @@ export const UPDATE_ENQUETE_INDIVIDUEL_INFORMATIONS = gql`
       }
     ) {
       sexe
+      exerce_seul_activite
       secretaire_specialise_etp
       local_professionnel
       last_update

--- a/packages/app/src/components/Enquete/EnqueteIndividuelInformations/queries.js
+++ b/packages/app/src/components/Enquete/EnqueteIndividuelInformations/queries.js
@@ -11,6 +11,7 @@ export const ENQUETE_INDIVIDUEL_INFORMATIONS_MANDATAIRE = gql`
       id
       last_update
       local_professionnel
+      exerce_seul_activite
       exerce_secretaires_specialises
       secretaire_specialise_etp
       sexe

--- a/packages/app/src/components/EnqueteImport/EnqueteImportPanel.js
+++ b/packages/app/src/components/EnqueteImport/EnqueteImportPanel.js
@@ -48,7 +48,7 @@ export const EnqueteImportPanel = ({ enqueteId, userId }) => {
           <Heading1 textAlign="center">Import des données</Heading1>
           <Flex flexDirection="column" mt="4" mb="3" sx={textStyle}>
             <Text>
-              {`Vous pouvez sélectionner la tableur excel envoyé par votre direction départementale
+              {`Vous pouvez sélectionner le tableur excel envoyé par votre direction départementale
               pour importer les données de l'enquête.`}
             </Text>
           </Flex>


### PR DESCRIPTION
Correction enquêtes mandataire #1889 #1801

__Onglet informations générales__

- [x] ajout champ manquant `exerce_seul_activite`
- [x] validation `secretaire_specialise_etp` en fonction de la réponse à `exerce_secretaires_specialises`
- [x] renommage composant `EnqueteIndividuelInformations` => `EnqueteIndividuelInformationsMandataire` pour meilleur lisibilité

__Onglet formation__

- [x] fix validation champs etp (suppression validateur "min" qui force la valeur a être un entier)