### PR TITLE
fix(app-in-docker-compose): can now connect and use app as before

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -12,8 +12,8 @@ POSTGRES_PASSWORD=test
 # API variables
 
 GRAPHQL_SERVER_URI=http://localhost:5000/v1/graphql
-GRAPHQL_SERVER_URI_DOCKER=http://graphql-engine:5000/v1/graphql
-HASURA_GRAPHQL_URI=http://graphql-engine:5000/v1/graphql
+GRAPHQL_SERVER_URI_DOCKER=http://graphql-engine:8080/v1/graphql
+HASURA_GRAPHQL_URI=http://graphql-engine:8080/v1/graphql
 API_URL_DOCKER=http://emjpm:4000
 HASURA_WEB_HOOK_BASE_URL=http://emjpm:4000
 HASURA_WEB_HOOK_SECRET=z1VJ23P54jQF9JEU5lXJaSVwpuM2vr9NT3ZAuesCNFFx7hrs5F8jrdv16Z3apCaN

--- a/.env.sample
+++ b/.env.sample
@@ -12,8 +12,8 @@ POSTGRES_PASSWORD=test
 # API variables
 
 GRAPHQL_SERVER_URI=http://localhost:5000/v1/graphql
-API_URL_DOCKER=http://host.docker.internal:4000
-HASURA_WEB_HOOK_BASE_URL=http://host.docker.internal:4000
+API_URL_DOCKER=http://emjpm:4000
+HASURA_WEB_HOOK_BASE_URL=http://emjpm:4000
 HASURA_WEB_HOOK_SECRET=z1VJ23P54jQF9JEU5lXJaSVwpuM2vr9NT3ZAuesCNFFx7hrs5F8jrdv16Z3apCaN
 JWT_KEY=abc120d67
 DATABASE_URL=psql://emjpm:test@db/emjpm

--- a/.env.sample
+++ b/.env.sample
@@ -12,6 +12,8 @@ POSTGRES_PASSWORD=test
 # API variables
 
 GRAPHQL_SERVER_URI=http://localhost:5000/v1/graphql
+GRAPHQL_SERVER_URI_DOCKER=http://graphql-engine:5000/v1/graphql
+HASURA_GRAPHQL_URI=http://graphql-engine:5000/v1/graphql
 API_URL_DOCKER=http://emjpm:4000
 HASURA_WEB_HOOK_BASE_URL=http://emjpm:4000
 HASURA_WEB_HOOK_SECRET=z1VJ23P54jQF9JEU5lXJaSVwpuM2vr9NT3ZAuesCNFFx7hrs5F8jrdv16Z3apCaN

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.8"
 
 #
 # In development we only start postgres server
@@ -60,6 +60,7 @@ services:
       - ./:/home/node/app
     ports:
       - 3000:3000
+      - 4000:4000
     restart: always
     command: "yarn dev"
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,6 +41,7 @@ services:
       - 5000:8080
     depends_on:
       - db
+      - emjpm
     restart: always
     environment:
       HASURA_GRAPHQL_ADMIN_SECRET: $HASURA_GRAPHQL_ADMIN_SECRET
@@ -50,6 +51,17 @@ services:
       HASURA_GRAPHQL_UNAUTHORIZED_ROLE: "anonymous"
       HASURA_WEB_HOOK_BASE_URL: $HASURA_WEB_HOOK_BASE_URL
       HASURA_WEB_HOOK_SECRET: $HASURA_WEB_HOOK_SECRET
+
+  emjpm:
+    image: node:10-alpine
+    user: "node"
+    working_dir: /home/node/app
+    volumes:
+      - ./:/home/node/app
+    ports:
+      - 3000:3000
+    restart: always
+    command: "yarn dev"
 
 volumes:
   emjpm-pgdata:

--- a/packages/api/knexfile.js
+++ b/packages/api/knexfile.js
@@ -19,10 +19,10 @@ module.exports = {
   development: {
     client: "pg",
     connection: process.env.DATABASE_URL || {
-      host: "localhost",
+      host: "db",
       user: "emjpm",
       password: "test",
-      port: "5434",
+      port: "5432",
       database: "emjpm",
     },
     migrations: {},

--- a/packages/app/next.config.js
+++ b/packages/app/next.config.js
@@ -27,6 +27,7 @@ module.exports = flow(
   publicRuntimeConfig: {
     API_URL: process.env.API_URL || "http://127.0.0.1:4000",
     GRAPHQL_SERVER_URI: process.env.GRAPHQL_SERVER_URI || "http://localhost:5000/v1/graphql",
+    GRAPHQL_SERVER_URI_DOCKER: process.env.GRAPHQL_SERVER_URI_DOCKER || process.env.GRAPHQL_SERVER_URI || "http://localhost:5000/v1/graphql",
     NODE_ENV: process.env.NODE_ENV,
     PACKAGE_VERSION: process.env.VERSION || require("./package.json").version,
     SENTRY_PUBLIC_DSN: process.env.SENTRY_PUBLIC_DSN,

--- a/packages/app/src/lib/apollo/init-apollo.js
+++ b/packages/app/src/lib/apollo/init-apollo.js
@@ -30,7 +30,7 @@ const getToken = (context) => {
 };
 
 const {
-  publicRuntimeConfig: { GRAPHQL_SERVER_URI },
+  publicRuntimeConfig: { GRAPHQL_SERVER_URI, GRAPHQL_SERVER_URI_DOCKER },
 } = getConfig();
 
 function create(initialState, context) {
@@ -52,9 +52,14 @@ function create(initialState, context) {
     };
   });
 
+  const adjustedUri =
+    isBrowser() && process.env.NODE_ENV === `development`
+      ? GRAPHQL_SERVER_URI
+      : GRAPHQL_SERVER_URI_DOCKER;
+
   const httpLink = createHttpLink({
     credentials: "same-origin",
-    uri: GRAPHQL_SERVER_URI,
+    uri: adjustedUri,
   });
 
   // Check out https://github.com/zeit/next.js/pull/4611 if you want to use the AWSAppSyncClient


### PR DESCRIPTION
cette PR termine de résoudre la PR #2323 et l'issue #2322

ça y est cette fois ci on peut se connecter et utiliser l'app normalement

@tglatt dans le .env
```
HASURA_GRAPHQL_URI=http://graphql-engine:8080/v1/graphql
GRAPHQL_SERVER_URI=http://localhost:5000/v1/graphql
GRAPHQL_SERVER_URI_DOCKER=http://graphql-engine:8080/v1/graphql
```

voir:
https://github.com/apollographql/apollo-link/issues/375#issuecomment-514840117
https://medium.com/@semur.nabiev/get-graphql-apollo-to-work-with-nextjs-ssr-within-docker-aa179ff0c2bc

PS:
`packages/api/knexfile.js` ne semble pas consommer le .env à la racine du projet, c'est ce que revèle un console.log sur `process.env.DATABASE_URL` donc, étant donné qu'il utilise les réglages par défaut (hardcodés), j'ai du changer le port de 5434 en 5432 pour l'env `development`