### PR TITLE
feat(admin-user): delete inactive user

### DIFF
--- a/packages/app/pages/admin/users/[user_id].js
+++ b/packages/app/pages/admin/users/[user_id].js
@@ -8,7 +8,7 @@ import { LayoutAdmin } from "../../../src/components/Layout";
 import { withAuthSync } from "../../../src/util/auth";
 
 const User = (props) => {
-  const { userId, type, active } = props;
+  const { userId } = props;
 
   return (
     <LayoutAdmin>
@@ -18,14 +18,14 @@ const User = (props) => {
             &larr; Retour
           </StyledLink>
         </Link>
-        <AdminUser userId={userId} active={active} type={type} />
+        <AdminUser userId={userId} />
       </BoxWrapper>
     </LayoutAdmin>
   );
 };
 
 User.getInitialProps = async ({ query }) => {
-  return { active: query.active, type: query.type, userId: query.user_id };
+  return { userId: query.user_id };
 };
 
 export default withAuthSync(User);

--- a/packages/app/pages/admin/users/[user_id]/delete.js
+++ b/packages/app/pages/admin/users/[user_id]/delete.js
@@ -1,0 +1,27 @@
+import { BoxWrapper } from "@emjpm/ui";
+import React from "react";
+import { Flex } from "rebass";
+
+import { AdminUserDelete } from "../../../../src/components/AdminUserDelete";
+import { LayoutAdmin } from "../../../../src/components/Layout";
+import { withAuthSync } from "../../../../src/util/auth";
+
+const AdminUserDeletePage = (props) => {
+  const { userId } = props;
+
+  return (
+    <LayoutAdmin>
+      <BoxWrapper mt="6" px="1">
+        <Flex flexWrap="wrap" mt="2">
+          <AdminUserDelete userId={userId} />
+        </Flex>
+      </BoxWrapper>
+    </LayoutAdmin>
+  );
+};
+
+AdminUserDeletePage.getInitialProps = async ({ query }) => {
+  return { userId: query.user_id };
+};
+
+export default withAuthSync(AdminUserDeletePage);

--- a/packages/app/src/components/AdminServices/AdminServiceMesures.js
+++ b/packages/app/src/components/AdminServices/AdminServiceMesures.js
@@ -66,7 +66,7 @@ const AdminServiceMesures = (props) => {
     }
   );
 
-  const allMesures = data ? data.mesures : [];
+  const allMesures = useMemo(() => (data ? data.mesures : []), [data]);
 
   const {
     inProgressMesuresCount,

--- a/packages/app/src/components/AdminUser/AdminUser.js
+++ b/packages/app/src/components/AdminUser/AdminUser.js
@@ -1,3 +1,4 @@
+import { useQuery } from "@apollo/react-hooks";
 import { isDirection, isMagistrat, isMandataire, isService } from "@emjpm/core";
 import React from "react";
 import { Box, Card } from "rebass";
@@ -11,9 +12,27 @@ import { DirectionEditInformations } from "../DirectionEditInformations";
 import { MagistratEditInformations } from "../MagistratEditInformations";
 import { MandataireEditInformations } from "../MandataireEditInformations";
 import { MesureImportPanel } from "../MesureImport";
+import { USER } from "./queries";
 
 const AdminUser = (props) => {
-  const { userId, type, active } = props;
+  const { userId } = props;
+
+  const { data, loading, error } = useQuery(USER, {
+    variables: {
+      userId: userId,
+    },
+  });
+
+  if (loading) {
+    return <div>loading</div>;
+  }
+
+  if (error) {
+    return <div>error</div>;
+  }
+
+  const { users_by_pk: user } = data;
+  const { type, active } = user;
 
   return (
     <Box>

--- a/packages/app/src/components/AdminUser/queries.js
+++ b/packages/app/src/components/AdminUser/queries.js
@@ -1,0 +1,11 @@
+import gql from "graphql-tag";
+
+export const USER = gql`
+  query adminUserQuery($userId: Int!) {
+    users_by_pk(id: $userId) {
+      id
+      type
+      active
+    }
+  }
+`;

--- a/packages/app/src/components/AdminUserActivation/AdminUserActivation.js
+++ b/packages/app/src/components/AdminUserActivation/AdminUserActivation.js
@@ -5,6 +5,7 @@ import React, { Fragment, useCallback } from "react";
 import { Box, Flex } from "rebass";
 
 import { FormGrayBox, FormInputBox } from "../AppForm";
+import { Link } from "../Commons";
 import { AdminMandataireListeBlanche } from "./AdminMandataireListeBlanche";
 import { ACTIVATE_USER, SEND_EMAIL_ACCOUNT_VALIDATION } from "./mutations";
 import { LB_USER, USER } from "./queries";
@@ -102,16 +103,30 @@ const AdminUserActivation = (props) => {
           <Heading4 mb={1}>{"Activer / Bloquer"}</Heading4>
         </FormGrayBox>
         <FormInputBox>
-          <Box>
-            <Button
-              disabled={isMandataire({ type }) && !mandataire.lb_user}
-              mr={2}
-              bg={activateButtonStyle}
-              onClick={toggleActivation}
-              isLoading={activateUserLoading}
-            >
-              {activateButtonText}
-            </Button>
+          <Box display="inline-flex">
+            <Box>
+              <Button
+                disabled={isMandataire({ type }) && !mandataire.lb_user}
+                mr={2}
+                bg={activateButtonStyle}
+                onClick={toggleActivation}
+                isLoading={activateUserLoading}
+              >
+                {activateButtonText}
+              </Button>
+            </Box>
+            {!active && (
+              <Box>
+                <Link
+                  href={`/admin/users/[user_id]/delete`}
+                  asLink={`/admin/users/${userId}/delete`}
+                >
+                  <Button mr={2} bg={"red"}>
+                    {"Supprimer cet utilisateur"}
+                  </Button>
+                </Link>
+              </Box>
+            )}
           </Box>
 
           {isMandataire({ type }) && mandataire && !mandataire.lb_user && (

--- a/packages/app/src/components/AdminUserDelete/AdminUserDelete.js
+++ b/packages/app/src/components/AdminUserDelete/AdminUserDelete.js
@@ -1,0 +1,15 @@
+import React from "react";
+import { Flex } from "rebass";
+
+import { AdminUserDeleteForm } from "./AdminUserDeleteForm";
+import { AdminUserDeleteRemoveStyle } from "./style";
+
+export const AdminUserDelete = (props) => {
+  const { userId } = props;
+
+  return (
+    <Flex sx={AdminUserDeleteRemoveStyle}>
+      <AdminUserDeleteForm userId={userId} />
+    </Flex>
+  );
+};

--- a/packages/app/src/components/AdminUserDelete/AdminUserDeleteForm.js
+++ b/packages/app/src/components/AdminUserDelete/AdminUserDeleteForm.js
@@ -23,21 +23,11 @@ export const AdminUserDeleteForm = (props) => {
     initialValues: {},
     onSubmit: async (_, { setSubmitting }) => {
       await deleteUser({
-        // awaitRefetchQueries: true,
-        // refetchQueries: [
-        //   {
-        //     query: USERS,
-        //     variables: {
-        //       offset: 0,
-        //     },
-        //   },
-        // ],
         variables: {
           userId: userId,
         },
       });
       setSubmitting(false);
-      Router.push(`/admin/users`);
     },
     validationSchema: adminUserDeleteSchema,
   });

--- a/packages/app/src/components/AdminUserDelete/AdminUserDeleteForm.js
+++ b/packages/app/src/components/AdminUserDelete/AdminUserDeleteForm.js
@@ -1,0 +1,91 @@
+import { useMutation } from "@apollo/react-hooks";
+import { Button, Heading3, Heading5 } from "@emjpm/ui";
+import { useFormik } from "formik";
+import Router from "next/router";
+import React from "react";
+import { Box, Flex, Text } from "rebass";
+
+import { adminUserDeleteSchema } from "../../lib/validationSchemas";
+// import { USERS } from "../AdminUsers/queries";
+import { DELETE_USER } from "./mutations";
+import { AdminUserDeleteRemoveStyle } from "./style";
+
+export const AdminUserDeleteForm = (props) => {
+  const { userId } = props;
+
+  const [deleteUser] = useMutation(DELETE_USER, {
+    onCompleted: async () => {
+      Router.push(`/admin/users`);
+    },
+  });
+
+  const formik = useFormik({
+    initialValues: {},
+    onSubmit: async (_, { setSubmitting }) => {
+      await deleteUser({
+        // awaitRefetchQueries: true,
+        // refetchQueries: [
+        //   {
+        //     query: USERS,
+        //     variables: {
+        //       offset: 0,
+        //     },
+        //   },
+        // ],
+        variables: {
+          userId: userId,
+        },
+      });
+      setSubmitting(false);
+      Router.push(`/admin/users`);
+    },
+    validationSchema: adminUserDeleteSchema,
+  });
+
+  return (
+    <Flex sx={AdminUserDeleteRemoveStyle}>
+      <Box bg="cardSecondary" p="5" width={[1, 3 / 5]}>
+        <Heading5 mb="1">{"Supprimer l'utilisateur"}</Heading5>
+        <Text mb="2" lineHeight="1.5">
+          {`Vous êtes sur le point de supprimer définitivement un utilisateur du système eMJPM. Toute suppression est irréversible.`}
+        </Text>
+        <Text lineHeight="1.5">{`Si vous souhaitez supprimer cet utilisateur, cliquez sur "Supprimer l'utilisateur".`}</Text>
+        <Text lineHeight="1.5">{`Dans le cas contraire, cliquez sur "Annuler".`}</Text>
+      </Box>
+      <Box p="5" width={[1, 2 / 5]}>
+        <Box mb="3">
+          <Heading3>{"Supprimer l'utilisateur"}</Heading3>
+        </Box>
+        <form onSubmit={formik.handleSubmit}>
+          <Flex justifyContent="flex-end">
+            <Box>
+              <Button
+                type="button"
+                mr="2"
+                variant="outline"
+                onClick={() => {
+                  Router.push(
+                    "/admin/users/[user_id]",
+                    `/admin/users/${userId}`,
+                    { shallow: true }
+                  );
+                }}
+              >
+                Annuler
+              </Button>
+            </Box>
+            <Box>
+              <Button
+                type="submit"
+                disabled={formik.isSubmitting}
+                isLoading={formik.isSubmitting}
+              >
+                {"Supprimer l'utilisateur"}
+              </Button>
+            </Box>
+          </Flex>
+        </form>
+      </Box>
+    </Flex>
+  );
+};

--- a/packages/app/src/components/AdminUserDelete/index.js
+++ b/packages/app/src/components/AdminUserDelete/index.js
@@ -1,0 +1,3 @@
+import { AdminUserDelete } from "./AdminUserDelete";
+
+export { AdminUserDelete };

--- a/packages/app/src/components/AdminUserDelete/mutations.js
+++ b/packages/app/src/components/AdminUserDelete/mutations.js
@@ -1,0 +1,9 @@
+import gql from "graphql-tag";
+
+export const DELETE_USER = gql`
+  mutation delete_user($userId: Int!) {
+    delete_users_by_pk(id: $userId) {
+      id
+    }
+  }
+`;

--- a/packages/app/src/components/AdminUserDelete/style.js
+++ b/packages/app/src/components/AdminUserDelete/style.js
@@ -1,0 +1,7 @@
+const AdminUserDeleteRemoveStyle = {
+  bg: "white",
+  flexWrap: "wrap",
+  width: "100%",
+};
+
+export { AdminUserDeleteRemoveStyle };

--- a/packages/app/src/components/AdminUserMandataire/AdminMandataireMesures.js
+++ b/packages/app/src/components/AdminUserMandataire/AdminMandataireMesures.js
@@ -47,7 +47,7 @@ const AdminMandataireMesures = (props) => {
     { loading: calculateMandataireMesuresLoading },
   ] = useMutation(CALCULATE_MANDATAIRE_MESURES);
 
-  const allMesures = data ? data.mesures : [];
+  const allMesures = useMemo(() => (data ? data.mesures : []), [data]);
 
   const {
     inProgressMesuresCount,

--- a/packages/app/src/components/AdminUsers/AdminUsers.js
+++ b/packages/app/src/components/AdminUsers/AdminUsers.js
@@ -61,10 +61,7 @@ const RowItem = ({ item }) => {
             )}
           </Flex>
           <Box mr="1" width="120px">
-            <Link
-              href={`/admin/users/[user_id]?type=${type}&active=${active}`}
-              as={`/admin/users/${id}?type=${type}&active=${active}`}
-            >
+            <Link href={`/admin/users/[user_id]`} as={`/admin/users/${id}`}>
               <Button>Voir</Button>
             </Link>
           </Box>

--- a/packages/app/src/components/Enquete/EnquetePopulations/EnquetePopulationsAutreMesures.js
+++ b/packages/app/src/components/Enquete/EnquetePopulations/EnquetePopulationsAutreMesures.js
@@ -42,7 +42,10 @@ export const EnquetePopulationsAutreMesures = (props) => {
     ],
   });
 
-  const populations = data ? data.enquete_reponses_populations_by_pk || {} : {};
+  const populations = useMemo(
+    () => (data ? data.enquete_reponses_populations_by_pk || {} : {}),
+    [data]
+  );
   const reponsePopulations = useMemo(
     () => removeAttributesPrefix(populations, "autre_mesures_"),
     [populations]

--- a/packages/app/src/components/Enquete/EnquetePopulations/EnquetePopulationsCuratelle.js
+++ b/packages/app/src/components/Enquete/EnquetePopulations/EnquetePopulationsCuratelle.js
@@ -43,7 +43,10 @@ export const EnquetePopulationsCuratelle = (props) => {
     ],
   });
 
-  const populations = data ? data.enquete_reponses_populations_by_pk || {} : {};
+  const populations = useMemo(
+    () => (data ? data.enquete_reponses_populations_by_pk || {} : {}),
+    [data]
+  );
   const reponsePopulations = useMemo(
     () => removeAttributesPrefix(populations, "curatelle_"),
     [populations]

--- a/packages/app/src/components/Enquete/EnquetePopulations/EnquetePopulationsMAJ.js
+++ b/packages/app/src/components/Enquete/EnquetePopulations/EnquetePopulationsMAJ.js
@@ -40,7 +40,10 @@ export const EnquetePopulationsMAJ = (props) => {
     ],
   });
 
-  const populations = data ? data.enquete_reponses_populations_by_pk || {} : {};
+  const populations = useMemo(
+    () => (data ? data.enquete_reponses_populations_by_pk || {} : {}),
+    [data]
+  );
   const reponsePopulations = useMemo(
     () => removeAttributesPrefix(populations, "maj_"),
     [populations]

--- a/packages/app/src/components/Enquete/EnquetePopulations/EnquetePopulationsSauvegardeJustice.js
+++ b/packages/app/src/components/Enquete/EnquetePopulations/EnquetePopulationsSauvegardeJustice.js
@@ -46,7 +46,10 @@ export const EnquetePopulationsSauvegardeJustice = (props) => {
     }
   );
 
-  const populations = data ? data.enquete_reponses_populations_by_pk || {} : {};
+  const populations = useMemo(
+    () => (data ? data.enquete_reponses_populations_by_pk || {} : {}),
+    [data]
+  );
   const reponsePopulations = useMemo(
     () => removeAttributesPrefix(populations, "sauvegarde_justice_"),
     [populations]

--- a/packages/app/src/components/Enquete/EnquetePopulations/EnquetePopulationsTutelle.js
+++ b/packages/app/src/components/Enquete/EnquetePopulations/EnquetePopulationsTutelle.js
@@ -40,7 +40,10 @@ export const EnquetePopulationsTutelle = (props) => {
     ],
   });
 
-  const populations = data ? data.enquete_reponses_populations_by_pk || {} : {};
+  const populations = useMemo(
+    () => (data ? data.enquete_reponses_populations_by_pk || {} : {}),
+    [data]
+  );
   const reponsePopulations = useMemo(
     () => removeAttributesPrefix(populations, "tutelle_"),
     [populations]

--- a/packages/app/src/lib/validationSchemas/adminUserDeleteSchema.js
+++ b/packages/app/src/lib/validationSchemas/adminUserDeleteSchema.js
@@ -1,0 +1,5 @@
+import yup from "./yup";
+
+const adminUserDeleteSchema = yup.object().shape({});
+
+export { adminUserDeleteSchema };

--- a/packages/app/src/lib/validationSchemas/index.js
+++ b/packages/app/src/lib/validationSchemas/index.js
@@ -1,5 +1,6 @@
 import { adminEditorSchema } from "./adminEditorSchema";
 import { adminTribunalSchema } from "./adminTribunalSchema";
+import { adminUserDeleteSchema } from "./adminUserDeleteSchema";
 import { adminUserServiceSchema } from "./adminUserServiceSchema";
 import { editorTokenSchema } from "./editorTokenSchema";
 import { forgotPasswordSchema } from "./forgotPasswordSchema";
@@ -27,6 +28,7 @@ export {
   adminEditorSchema,
   adminTribunalSchema,
   adminUserServiceSchema,
+  adminUserDeleteSchema,
   forgotPasswordSchema,
   loginSchema,
   magistratEditSchema,

--- a/packages/hasura/migrations/1607615995461_user_fk_cascade/down.sql
+++ b/packages/hasura/migrations/1607615995461_user_fk_cascade/down.sql
@@ -1,0 +1,48 @@
+
+alter table "public"."service_members" drop constraint "service_members_user_id_fkey",
+          add constraint "service_admin_user_id_foreign"
+          foreign key ("user_id")
+          references "public"."users"
+          ("id")
+          on update no action
+          on delete no action;
+
+alter table "public"."mandataires" drop constraint "mandataires_user_id_fkey",
+          add constraint "mandataires_user_id_foreign"
+          foreign key ("user_id")
+          references "public"."users"
+          ("id")
+          on update no action
+          on delete no action;
+
+alter table "public"."mandataire_tis" drop constraint "mandataire_tis_mandataire_id_fkey",
+          add constraint "mandataire_tis_mandataire_id_foreign"
+          foreign key ("mandataire_id")
+          references "public"."mandataires"
+          ("id")
+          on update no action
+          on delete no action;
+
+alter table "public"."magistrat" drop constraint "magistrat_user_id_fkey",
+          add constraint "magistrat_user_id_foreign"
+          foreign key ("user_id")
+          references "public"."users"
+          ("id")
+          on update no action
+          on delete no action;
+
+alter table "public"."direction" drop constraint "direction_user_id_fkey",
+          add constraint "direction_user_id_foreign"
+          foreign key ("user_id")
+          references "public"."users"
+          ("id")
+          on update no action
+          on delete no action;
+
+alter table "public"."user_role" drop constraint "user_role_user_id_fkey",
+          add constraint "user_role_user_id_foreign"
+          foreign key ("user_id")
+          references "public"."users"
+          ("id")
+          on update no action
+          on delete no action;

--- a/packages/hasura/migrations/1607615995461_user_fk_cascade/up.sql
+++ b/packages/hasura/migrations/1607615995461_user_fk_cascade/up.sql
@@ -1,0 +1,36 @@
+
+alter table "public"."user_role" drop constraint "user_role_user_id_foreign",
+             add constraint "user_role_user_id_fkey"
+             foreign key ("user_id")
+             references "public"."users"
+             ("id") on update cascade on delete cascade;
+
+alter table "public"."direction" drop constraint "direction_user_id_foreign",
+             add constraint "direction_user_id_fkey"
+             foreign key ("user_id")
+             references "public"."users"
+             ("id") on update cascade on delete cascade;
+
+alter table "public"."magistrat" drop constraint "magistrat_user_id_foreign",
+             add constraint "magistrat_user_id_fkey"
+             foreign key ("user_id")
+             references "public"."users"
+             ("id") on update cascade on delete cascade;
+
+alter table "public"."mandataire_tis" drop constraint "mandataire_tis_mandataire_id_foreign",
+             add constraint "mandataire_tis_mandataire_id_fkey"
+             foreign key ("mandataire_id")
+             references "public"."mandataires"
+             ("id") on update cascade on delete cascade;
+
+alter table "public"."mandataires" drop constraint "mandataires_user_id_foreign",
+             add constraint "mandataires_user_id_fkey"
+             foreign key ("user_id")
+             references "public"."users"
+             ("id") on update cascade on delete cascade;
+
+alter table "public"."service_members" drop constraint "service_admin_user_id_foreign",
+             add constraint "service_members_user_id_fkey"
+             foreign key ("user_id")
+             references "public"."users"
+             ("id") on update cascade on delete cascade;


### PR DESCRIPTION
UI: OK (enfin il me semble, à moins qu'il faille rajouter un champs texte pour enregistrer la raison de la supression)

Migration: j'ai opté pour un delete en cascade, selon la team hasura c'est la bonne option (see https://github.com/hasura/graphql-engine/issues/1736#issuecomment-471937346), j'ai trouvé la commande squash dont tu m'as parlé sur la migration hasura ;)

J'ai aussi nettoyé l'URI sur admin/users/[user_id], plutôt que d'accorder une confiance aux paramètres `type` et `active` dans l'url je me suis basé sur l'user_id pour les charger (ce qui a simplifié la navigation, sinon on aurais continué à s'embourber là dedans en relayant sans cesse ces paramètres).

Au moment de commiter le linter m'a forcé de manière intransigeante à mettre des useMemo un peu partout dans des fichiers sur lesquels je n'avais pourtant pas travaillé, je me suis dit qu'il y avait peut-être eu une mise à jour de ses règles ou que sais-je, je me suis donc exécuté (d'où tous les fichiers sans rapport avec des useMemo en plus)

Il reste une chose à faire, c'est implémenter côté serveur la limitation de droits pour empêcher de supprimer un utilisateur actif (pour le moment cette limitation n'est présente que dans l'UI, je ne pense pas que quelqu'un avec des droits admin s'amuse à forger des requêtes mais ce sera plus sur).

Dernière chose, concernant l'update du cache, sur la query USERS il y a  `fetchPolicy: "network-only"`, donc il me semble pas qu'il y ai un cache apollo, j'avais commencé à faire un refetch (en me basant sur ce que j'ai vu ailleurs dans le code), dans la doc apollo j'ai aussi vu qu'on pouvait agir directement sur le cache mais je ne sais pas si c'est très adapté. Comme tu verras, je l'ai commenté car cela fonctionne et aussi à cause du `fetchPolicy: "network-only"` dans `AdminUsers.js`